### PR TITLE
Update dependabot to open PRs monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10


### PR DESCRIPTION
This crate has very few PRs, so there is no reason to keep updating dependabot.