### PR TITLE
Remove libc runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming Release
+
+## Changed
+- Use raw syscalls instead of libc
+
 # v0.4.0
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ json = ["serde", "serde_json"]
 
 [dependencies]
 libc = "^0.2.39"
+linux-syscalls = "^0.3.2"
 serde = { version = "^1.0.27", features = ["derive"], optional = true}
 serde_json = {version = "^1.0.9", optional = true}


### PR DESCRIPTION
### Summary of the PR

With this PR the library has no runtime dependencies  except rust's global allocator. This could mean an ever so slightly security increase, because raw syscalls are not subject to `LD_PRELOAD`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
