### PR TITLE
Don't install program bigger than 4096 instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming Release
+
+## Changed
+- Do not try to install a programm with more than 65,535 instructions
+
 # v0.4.0
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming Release
 
 ## Changed
-- Do not try to install a programm with more than 65,535 instructions
+- Do not try to install a programm with more than 4096 instructions
 
 # v0.4.0
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use core::fmt::Formatter;
 use std::fmt::Display;
 
-use bpf::{
+pub(crate) use bpf::{
     ARG_NUMBER_MAX, AUDIT_ARCH_AARCH64, AUDIT_ARCH_X86_64, BPF_MAX_LEN, SECCOMP_RET_ALLOW,
     SECCOMP_RET_ERRNO, SECCOMP_RET_KILL_PROCESS, SECCOMP_RET_KILL_THREAD, SECCOMP_RET_LOG,
     SECCOMP_RET_MASK, SECCOMP_RET_TRACE, SECCOMP_RET_TRAP,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,8 +233,8 @@ pub enum Error {
     Backend(BackendError),
     /// Attempting to install an empty filter.
     EmptyFilter,
-    /// Attempting to install a filter with more than [`u16::MAX`] instructions.
-    TooManyInstructions(std::num::TryFromIntError),
+    /// Attempting to install a filter with more than 4095 instructions.
+    TooManyInstructions,
     /// System error related to calling `prctl`.
     Prctl(io::Error),
     /// System error related to calling `seccomp` syscall.
@@ -258,7 +258,6 @@ impl std::error::Error for Error {
             ThreadSync(_) => None,
             #[cfg(feature = "json")]
             JsonFrontend(error) => Some(error),
-            TooManyInstructions(error) => Some(error),
             _ => None,
         }
     }
@@ -275,10 +274,11 @@ impl Display for Error {
             EmptyFilter => {
                 write!(f, "Cannot install empty filter.")
             }
-            TooManyInstructions(_) => {
+            TooManyInstructions => {
                 write!(
                     f,
-                    "Cannot install filter with more than 65535 instructions."
+                    "Cannot install filter with more than {} instructions.",
+                    backend::BPF_MAX_LEN
                 )
             }
             Prctl(errno) => {
@@ -346,16 +346,14 @@ pub fn apply_filter_all_threads(bpf_filter: BpfProgramRef) -> Result<()> {
 ///
 /// [`BpfProgram`]: type.BpfProgram.html
 fn apply_filter_with_flags(bpf_filter: BpfProgramRef, flags: libc::c_ulong) -> Result<()> {
-    // If the program is empty, don't install the filter.
-    if bpf_filter.is_empty() {
-        return Err(Error::EmptyFilter);
-    }
-
+    // If the program size is invalid, don't install the filter.
+    let len = match bpf_filter.len() {
+        len @ 1..=backend::BPF_MAX_LEN => len as u16,
+        0 => return Err(Error::EmptyFilter),
+        _ => return Err(Error::TooManyInstructions),
+    };
     let bpf_prog = sock_fprog {
-        len: bpf_filter
-            .len()
-            .try_into()
-            .map_err(Error::TooManyInstructions)?,
+        len,
         filter: bpf_filter.as_ptr(),
     };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -789,3 +789,20 @@ fn test_filter_apply() {
     .join()
     .unwrap();
 }
+
+#[test]
+fn test_u16_overflow() {
+    let rule = sock_filter {
+        code: 6,
+        jt: 0,
+        jf: 0,
+        k: 0,
+    };
+    let rules = vec![rule; 0x10_000];
+    let err = seccompiler::apply_filter(&rules).unwrap_err();
+    assert!(matches!(err, seccompiler::Error::TooManyInstructions));
+    assert_eq!(
+        err.to_string(),
+        "Cannot install filter with more than 65535 instructions."
+    );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -800,7 +800,7 @@ fn test_u16_overflow() {
     };
     let rules = vec![rule; 0x10_000];
     let err = seccompiler::apply_filter(&rules).unwrap_err();
-    assert!(matches!(err, seccompiler::Error::TooManyInstructions));
+    assert!(matches!(err, seccompiler::Error::TooManyInstructions(_)));
     assert_eq!(
         err.to_string(),
         "Cannot install filter with more than 65535 instructions."

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -714,7 +714,7 @@ fn test_filter_apply() {
         // Apply seccomp filter.
         assert!(matches!(
             apply_filter(&filter).unwrap_err(),
-            Error::Seccomp(_)
+            Error::TooManyInstructions
         ));
     })
     .join()
@@ -800,9 +800,9 @@ fn test_u16_overflow() {
     };
     let rules = vec![rule; 0x10_000];
     let err = seccompiler::apply_filter(&rules).unwrap_err();
-    assert!(matches!(err, seccompiler::Error::TooManyInstructions(_)));
+    assert!(matches!(err, seccompiler::Error::TooManyInstructions));
     assert_eq!(
         err.to_string(),
-        "Cannot install filter with more than 65535 instructions."
+        "Cannot install filter with more than 4096 instructions."
     );
 }


### PR DESCRIPTION
### Summary of the PR

`sock_fprog::len` is a u16, so a program can have at most 65535 instructions, which is more than plenty. Nevertheless the `apply_filter()` should return an error if someone calls it with `&[sock_filter {...}; 0x10_000]` instead of installing an empty filter (0x10000 % 0x10000 == 0).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] ~~Any newly added `unsafe` code is properly documented.~~
