### PR TITLE
Add optional `E` argument to `Result` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming Release
+
+## Changed
+- Add optional `E` argument to `Result` type
+
 # v0.4.0
 
 ## Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ struct sock_fprog {
 }
 
 /// Library Result type.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 ///`BpfMap` is another type exposed by the library, which maps thread categories to BPF programs.
 pub type BpfMap = HashMap<String, BpfProgram>;


### PR DESCRIPTION
### Summary of the PR

This way `Result<T, MyError>` still works even if someone uses the library with `use seccompiler::*`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] ~~Any newly added `unsafe` code is properly documented.~~
