### PR TITLE
Add docs for json feature, make frontend error pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+- [[#91]](https://github.com/rust-vmm/seccompiler/pull/91): Actually make
+  `JsonFrontendError` type publicly accessible, this type is referred to in a
+  public variant of `Error` but was not accessible outside the crate.
+
 # v0.5.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["seccomp", "jail", "sandbox"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 json = ["serde", "serde_json"]
 

--- a/src/frontend/json.rs
+++ b/src/frontend/json.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Deserializer};
 type Result<T> = result::Result<T, Error>;
 
 /// Error compiling JSON into IR.
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 #[derive(Debug)]
 pub enum Error {
     /// Backend error creating the `SeccompFilter` IR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,8 @@
 //! [`SeccompRule`]: struct.SeccompRule.html
 //! [`SeccompAction`]: enum.SeccompAction.html
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod backend;
 #[cfg(feature = "json")]
 mod frontend;
@@ -200,8 +202,11 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 #[cfg(feature = "json")]
-use frontend::json::{Error as JsonFrontendError, JsonCompiler};
+pub use frontend::json::Error as JsonFrontendError;
+#[cfg(feature = "json")]
+use frontend::json::JsonCompiler;
 
 // Re-export the IR public types.
 pub use backend::{
@@ -238,6 +243,7 @@ pub enum Error {
     /// of the thread that caused the failure.
     ThreadSync(libc::c_long),
     /// Json Frontend Error.
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     #[cfg(feature = "json")]
     JsonFrontend(JsonFrontendError),
 }
@@ -295,6 +301,7 @@ impl From<BackendError> for Error {
         Self::Backend(value)
     }
 }
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 #[cfg(feature = "json")]
 impl From<JsonFrontendError> for Error {
     fn from(value: JsonFrontendError) -> Self {


### PR DESCRIPTION
### Summary of the PR

- Build all features on docs.rs
- Add a `docsrs` cfg attr and add to items that are public but only when the json feature is enabled
-  Make the `JsonFrontendError` type nameable, this type is referred to in a public variant of `Error` but was not accessible outside the crate.

### Screenshots

**index**

<img width="867" height="429" alt="image" src="https://github.com/user-attachments/assets/a98379eb-36cf-4cc7-8d0d-d87c0e139b7e" />

**Error**

<img width="642" height="240" alt="image" src="https://github.com/user-attachments/assets/46b14429-5e23-45e0-87fa-aceafdd02a96" />


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
