### PR TITLE
Document behavior with duplicate keys when collecting into BTreeMap

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,6 +15,9 @@ use std::convert::TryInto;
 use std::env::consts::ARCH;
 use std::thread;
 
+use libc::SYS_read;
+
+
 // The type of the `req` parameter is different for the `musl` library. This will enable
 // successful build for other non-musl libraries.
 #[cfg(target_env = "musl")]
@@ -788,4 +791,16 @@ fn test_filter_apply() {
     })
     .join()
     .unwrap();
+}
+
+#[test]
+fn test_duplicate_syscall_keys_override_previous_rules() {
+    let rules = vec![
+        (SYS_read, 1),
+        (SYS_read, 2),
+    ];
+
+    let map: BTreeMap<_, _> = rules.into_iter().collect();
+
+    assert_eq!(map.len(), 1);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,7 +17,6 @@ use std::thread;
 
 use libc::SYS_read;
 
-
 // The type of the `req` parameter is different for the `musl` library. This will enable
 // successful build for other non-musl libraries.
 #[cfg(target_env = "musl")]
@@ -795,10 +794,7 @@ fn test_filter_apply() {
 
 #[test]
 fn test_duplicate_syscall_keys_override_previous_rules() {
-    let rules = vec![
-        (SYS_read, 1),
-        (SYS_read, 2),
-    ];
+    let rules = vec![(SYS_read, 1), (SYS_read, 2)];
 
     let map: BTreeMap<_, _> = rules.into_iter().collect();
 


### PR DESCRIPTION
This PR adds a small integration test documenting the behavior of collecting
duplicate keys into a BTreeMap.

When duplicate keys are provided, the last entry overwrites previous ones.
No behavior change is intended; this test only makes the existing semantics explicit.