### PR TITLE
syscall_table: expose get_syscall_nr without json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 
 [features]
-json = ["serde", "serde_json"]
+json = ["serde", "serde_json", "syscall-table"]
+syscall-table = []
 
 [dependencies]
 libc = "^0.2.153"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 mod backend;
 #[cfg(feature = "json")]
 mod frontend;
-#[cfg(feature = "json")]
+#[cfg(feature = "syscall-table")]
 mod syscall_table;
 
 #[cfg(feature = "json")]
@@ -208,6 +208,8 @@ pub use backend::{
     sock_filter, BpfProgram, BpfProgramRef, Error as BackendError, SeccompAction, SeccompCmpArgLen,
     SeccompCmpOp, SeccompCondition, SeccompFilter, SeccompRule, TargetArch,
 };
+#[cfg(feature = "syscall-table")]
+pub use syscall_table::SyscallTable;
 
 // BPF structure definition for filter array.
 // See /usr/include/linux/filter.h .

--- a/src/syscall_table/mod.rs
+++ b/src/syscall_table/mod.rs
@@ -8,13 +8,17 @@ mod x86_64;
 use crate::backend::TargetArch;
 use std::collections::HashMap;
 
-/// Creates and owns a mapping from the arch-specific syscall name to the right number.
+/// Owns a mapping from arch-specific syscall name to syscall number.
+///
+/// Build once with [`new`](Self::new) and reuse it for repeated lookups via
+/// [`get_syscall_nr`](Self::get_syscall_nr).
 #[derive(Debug)]
-pub(crate) struct SyscallTable {
+pub struct SyscallTable {
     map: HashMap<&'static str, i64>,
 }
 
 impl SyscallTable {
+    /// Builds the syscall name -> number table for `arch`.
     pub fn new(arch: TargetArch) -> Self {
         Self {
             map: match arch {
@@ -26,6 +30,8 @@ impl SyscallTable {
     }
 
     /// Returns the arch-specific syscall number based on the given name.
+    ///
+    /// Returns `None` if `sys_name` is not present in the table.
     pub fn get_syscall_nr(&self, sys_name: &str) -> Option<i64> {
         self.map.get(sys_name).copied()
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,6 +11,8 @@ use seccompiler::{
     apply_filter, sock_filter, BpfProgram, Error, SeccompAction, SeccompCondition as Cond,
     SeccompFilter, SeccompRule,
 };
+#[cfg(feature = "syscall-table")]
+use seccompiler::{SyscallTable, TargetArch};
 use std::convert::TryInto;
 use std::env::consts::ARCH;
 use std::thread;
@@ -788,4 +790,30 @@ fn test_filter_apply() {
     })
     .join()
     .unwrap();
+}
+
+#[test]
+#[cfg(feature = "syscall-table")]
+fn test_syscall_table_public() {
+    let arch = TargetArch::try_from(ARCH).unwrap();
+    let table = SyscallTable::new(arch);
+
+    assert_eq!(table.get_syscall_nr("close"), Some(libc::SYS_close));
+    assert_eq!(table.get_syscall_nr("read"), Some(libc::SYS_read));
+    assert_eq!(table.get_syscall_nr("write"), Some(libc::SYS_write));
+    assert!(table.get_syscall_nr("this_is_not_a_syscall").is_none());
+
+    // Cross-arch tables stay reachable without the json feature.
+    assert_eq!(
+        SyscallTable::new(TargetArch::x86_64).get_syscall_nr("close"),
+        Some(3)
+    );
+    assert_eq!(
+        SyscallTable::new(TargetArch::aarch64).get_syscall_nr("close"),
+        Some(57)
+    );
+    assert_eq!(
+        SyscallTable::new(TargetArch::riscv64).get_syscall_nr("close"),
+        Some(57)
+    );
 }


### PR DESCRIPTION
## Summary

Expose architecture-specific syscall name lookup for callers that build filters in Rust without using the JSON frontend.

- Always compile `syscall_table` (no longer gated on the `json` feature)
- Add public `get_syscall_nr(name, arch) -> Option<i64>`
- Unit and integration tests for host and cross-arch lookups

## Rationale

[hakoniwa](https://github.com/souk4711/hakoniwa) could move its seccomp backend from libseccomp to seccompiler. It keeps its own filter IR and OCI/podman-style profile loader; it only needs seccompiler for name→number resolution, BPF compilation, and install.

Today the syscall tables are only linked when the `json` feature is enabled, so a pure library consumer cannot resolve names like `"openat"` without also pulling in the JSON frontend. `get_syscall_nr` fills that gap in the same way programmatic builders need (and matches the “skip unknown syscalls” pattern used with libseccomp’s name lookup).

This is a small, self-contained slice of that work; further PRs will cover per-rule actions, optional `PR_SET_NO_NEW_PRIVS`, and related install helpers.

## Testing

```bash
cargo test
cargo test --features json
cargo fmt --check
```
